### PR TITLE
feat(print): add version numbers to output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ fn print_project(project: &WorkspaceInfo) {
 
     for (_, pkg) in project.packages() {
         let pkg_name = &pkg.name;
+        let pkg_version = &pkg.version;
 
         // Determine if this package's binaries should be Released
         let mut disabled_reason = None;
@@ -54,7 +55,7 @@ fn print_project(project: &WorkspaceInfo) {
                     ));
                 }
             } else if let Some(ver) = &announcing_version {
-                if &pkg.version != ver {
+                if pkg_version != ver {
                     disabled_reason = Some(format!(
                         "didn't match tag {}",
                         announcement_tag.as_ref().unwrap()
@@ -67,10 +68,21 @@ fn print_project(project: &WorkspaceInfo) {
         let sty;
         if let Some(reason) = &disabled_reason {
             sty = &disabled_sty;
-            eprintln!("  {}", sty.apply_to(format!("{pkg_name} ({reason})")));
+            if let Some(version) = pkg_version {
+                eprintln!(
+                    "  {}",
+                    sty.apply_to(format!("{pkg_name}@{version} ({reason})"))
+                );
+            } else {
+                eprintln!("  {}", sty.apply_to(format!("{pkg_name} ({reason})")));
+            }
         } else {
             sty = &enabled_sty;
-            eprintln!("  {}", sty.apply_to(pkg_name));
+            if let Some(version) = pkg_version {
+                eprintln!("  {}@{version}", sty.apply_to(pkg_name));
+            } else {
+                eprintln!("  {}", sty.apply_to(pkg_name));
+            }
         }
 
         // Report each binary and potentially add it to the Release for this package


### PR DESCRIPTION
```
ag_dubs@Ashleys-MBP-2 cargo-new % ../../../target/debug/axoproject
  cargo-new@0.1.0
    [bin] cargo-new

ag_dubs@Ashleys-MBP-2 cargo-new % cd ..
ag_dubs@Ashleys-MBP-2 projects % cd npm-init-legacy
ag_dubs@Ashleys-MBP-2 npm-init-legacy % ../../../target/debug/axoproject
  npm-init-legacy@1.0.0 (no binaries)

ag_dubs@Ashleys-MBP-2 npm-init-legacy % cd ../npm-create-react-app
ag_dubs@Ashleys-MBP-2 npm-create-react-app % ../../../target/debug/axoproject
  npm-create-react-app@0.1.0 (no binaries)

```