### PR TITLE
feat: support extracting keywords (and categories)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /target
 /tests/projects/*/target
+
+# why did you generate this in the first place vscode? huh? huh???
+.vscode/

--- a/src/javascript.rs
+++ b/src/javascript.rs
@@ -92,6 +92,13 @@ fn read_workspace(manifest_path: Utf8PathBuf) -> Result<WorkspaceInfo> {
         .collect::<Vec<_>>();
     binaries.sort();
 
+    let keywords = if manifest.keywords.is_empty() {
+        None
+    } else {
+        // `manifest.keywords` is a `Vec<String, Global>`, which we need to normalize.
+        Some(manifest.keywords.into_iter().collect::<Vec<String>>())
+    };
+
     let mut info = PackageInfo {
         name: package_name,
         version,
@@ -104,6 +111,7 @@ fn read_workspace(manifest_path: Utf8PathBuf) -> Result<WorkspaceInfo> {
         publish: true,
         repository_url: repository_url.clone(),
         homepage_url: manifest.homepage,
+        keywords,
         // FIXME: is there any JS equivalent to this?
         documentation_url: None,
         // FIXME: is there any JS equivalent to this?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,6 +180,13 @@ pub struct PackageInfo {
     ///
     /// Currently always true for npm packages.
     pub publish: bool,
+    /// Package keywords AND/OR categories.
+    ///
+    /// Specifically, Cargo has both the notion
+    /// of a "package keyword" (free-form text) and a "package category" (one of circa 70
+    /// predefined categories accepted by crates.io). We don't really care about validating
+    /// these, though, and just squash them together with the keywords.
+    pub keywords: Option<Vec<String>>,
     /// URL to the repository for this package
     ///
     /// This URL can be used by various CI/Installer helpers. In the future we

--- a/src/rust.rs
+++ b/src/rust.rs
@@ -210,6 +210,16 @@ fn package_info(_workspace_root: &Utf8Path, package: &PackageMetadata) -> Result
         }
     }
 
+    let keywords_and_categories: Option<Vec<String>> =
+        if package.keywords().is_empty() && package.categories().is_empty() {
+            None
+        } else {
+            let categories = package.categories().to_vec();
+            let mut keywords = package.keywords().to_vec();
+            keywords.extend(categories);
+            Some(keywords)
+        };
+
     let mut info = PackageInfo {
         name: package.name().to_owned(),
         version: Some(Version::Cargo(package.version().clone())),
@@ -217,6 +227,7 @@ fn package_info(_workspace_root: &Utf8Path, package: &PackageMetadata) -> Result
         package_root: package_root.clone(),
         description: package.description().map(ToOwned::to_owned),
         authors: package.authors().to_vec(),
+        keywords: keywords_and_categories,
         license: package.license().map(ToOwned::to_owned),
         publish: !package.publish().is_never(),
         repository_url: package.repository().map(ToOwned::to_owned),


### PR DESCRIPTION
Does what it says. Closes #16. I figured it'd be more ergonomic to make keywords an `Option`, while both guppy and oro-common return empty string Vecs/slices, the field _is_ optional in both manifest formats.