### PR TITLE
feat(changelog): migrate parse_changelog logic to axoproject

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,6 +147,7 @@ dependencies = [
  "node-semver",
  "oro-common",
  "oro-package-spec",
+ "parse-changelog",
  "pathdiff",
  "semver",
  "serde",
@@ -738,6 +745,7 @@ checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.0",
+ "serde",
 ]
 
 [[package]]
@@ -801,6 +809,12 @@ name = "lebe"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
+
+[[package]]
+name = "lexopt"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baff4b617f7df3d896f97fe922b64817f6cd9a756bb81d40f8883f2f66dcb401"
 
 [[package]]
 name = "libc"
@@ -1047,6 +1061,22 @@ name = "owo-colors"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+
+[[package]]
+name = "parse-changelog"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a24196a65fc15a0a747df8c041abc5a009f2c09c550b0a14f7eeb0c10255ef"
+dependencies = [
+ "anyhow",
+ "indexmap 2.0.0",
+ "lexopt",
+ "memchr",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "pathdiff"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ clap = { version = "4.2.1", features = ["derive"] }
 pathdiff = { version = "0.2.1", features = ["camino"] }
 itertools = "0.10.5"
 url = "2.4.0"
+parse-changelog = "0.6.1"
 
 # The profile that 'cargo dist' will build with
 [profile.dist]

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -1,0 +1,146 @@
+//! Support for interpretting changelogs
+
+use camino::Utf8Path;
+
+use crate::errors::Result;
+use crate::{PackageInfo, Version, WorkspaceInfo};
+
+/// Info about a changelog entry
+#[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Clone)]
+pub struct ChangelogInfo {
+    /// Title of the entry
+    pub title: String,
+    /// Body of the entry
+    pub body: String,
+}
+
+impl WorkspaceInfo {
+    /// Get the changelog for a given version from the root workspace's changelog
+    pub fn changelog_for_version(&self, version: &Version) -> Result<Option<ChangelogInfo>> {
+        if let Some(changelog_path) = self.root_auto_includes.changelog.as_deref() {
+            changelog_for_version(changelog_path, version)
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+impl PackageInfo {
+    /// Get the changelog for a given version from a package's changelog
+    pub fn changelog_for_version(&self, version: &Version) -> Result<Option<ChangelogInfo>> {
+        if let Some(changelog_path) = self.changelog_file.as_deref() {
+            changelog_for_version(changelog_path, version)
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+/// Get the changelog for a version
+pub fn changelog_for_version(
+    changelog_path: &Utf8Path,
+    version: &Version,
+) -> Result<Option<ChangelogInfo>> {
+    // Load and parse the changelog
+    let changelog_str = axoasset::LocalAsset::load_string(changelog_path)?;
+    changelog_for_version_inner(changelog_path, &changelog_str, version)
+}
+
+/// Get the changelog for a version (inner version for testing)
+pub fn changelog_for_version_inner(
+    changelog_path: &Utf8Path,
+    changelog_str: &str,
+    version: &Version,
+) -> Result<Option<ChangelogInfo>> {
+    let changelogs = parse_changelog::parse(changelog_str)?;
+
+    // Try to extract the changelog entry for the given version.
+    //
+    // First, try to find the exact version.
+    //
+    // If that fails, try to find this version without the prerelease suffix.
+    // Because releasing a prerelease for a version that was already published before does not
+    // make much sense it is fairly safe to assume that this entry is in fact just our WIP state
+    // of the release notes.
+    //
+    // If that fails, try to find a section called "Unreleased" and use that (if it's a prerelease).
+    if let Some(info) = try_extract_changelog_exact(&changelogs, version)
+        .or_else(|| try_extract_changelog_normalized(&changelogs, version))
+        .or_else(|| try_extract_changelog_unreleased(&changelogs, version))
+    {
+        Ok(Some(info))
+    } else {
+        Err(crate::errors::AxoprojectError::ChangelogVersionNotFound {
+            path: changelog_path.to_owned(),
+            version: version.clone(),
+        })
+    }
+}
+
+/// Tries to find a changelog entry with the exact version given and returns its title and notes.
+fn try_extract_changelog_exact(
+    changelogs: &parse_changelog::Changelog,
+    version: &Version,
+) -> Option<ChangelogInfo> {
+    let version_string = format!("{}", version);
+
+    changelogs
+        .get(&*version_string)
+        .map(|release_notes| ChangelogInfo {
+            title: release_notes.title.to_string(),
+            body: release_notes.notes.to_string(),
+        })
+}
+
+/// Tries to find a changelog entry that matches the given version's normalized form. That is, just
+/// the `major.minor.patch` part. If successful, the entry's title is modified to include the
+/// version's prerelease part before it is returned together with the notes.
+///
+/// Noop if the given version is already normalized.
+fn try_extract_changelog_normalized(
+    changelogs: &parse_changelog::Changelog,
+    version: &Version,
+) -> Option<ChangelogInfo> {
+    if version.is_stable() {
+        return None;
+    }
+
+    let stable_version = version.stable_part();
+    let stable_version_string = format!("{}", stable_version);
+
+    let release_notes = changelogs.get(&*stable_version_string)?;
+
+    // title looks something like '<prefix><version><freeform>'
+    // `prefix` could be 'v' or 'Version ' for example
+    let Some((prefix, freeform)) = release_notes.title.split_once(&stable_version_string) else {
+        return None;
+    };
+
+    // insert prerelease suffix into the title
+    let title = format!("{}{}{}", prefix, version, freeform);
+
+    Some(ChangelogInfo {
+        title,
+        body: release_notes.notes.to_string(),
+    })
+}
+
+// Tries to find the "Unreleased" changelog heading and replaces it with "Version {version}"
+//
+// Noop if the given version isn't a prerelease.
+fn try_extract_changelog_unreleased(
+    changelogs: &parse_changelog::Changelog,
+    version: &Version,
+) -> Option<ChangelogInfo> {
+    if version.is_stable() {
+        return None;
+    }
+
+    let release_notes = changelogs.get("Unreleased")?;
+    let title = format!("Version {version}");
+
+    Some(ChangelogInfo {
+        title,
+        body: release_notes.notes.to_string(),
+    })
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -4,6 +4,8 @@ use camino::Utf8PathBuf;
 use miette::Diagnostic;
 use thiserror::Error;
 
+use crate::Version;
+
 /// A Result returned by Axoproject
 pub type Result<T> = std::result::Result<T, AxoprojectError>;
 
@@ -20,6 +22,10 @@ pub enum AxoprojectError {
     #[cfg(feature = "cargo-projects")]
     #[error(transparent)]
     CargoMetadata(#[from] guppy::Error),
+
+    /// An error occured in parse_changelog
+    #[error(transparent)]
+    ParseChangelog(#[from] parse_changelog::Error),
 
     /// An error parsing a Cargo.toml
     #[cfg(feature = "cargo-projects")]
@@ -106,5 +112,14 @@ pub enum AxoprojectError {
     NotGitHubError {
         /// URL to the repository
         url: String,
+    },
+
+    /// We searched a changelog file but found no result
+    #[error("couldn't find a suitable changelog entry for {version} in {path}")]
+    ChangelogVersionNotFound {
+        /// Path of the file
+        path: Utf8PathBuf,
+        /// Version we were looking for
+        version: Version,
     },
 }


### PR DESCRIPTION
This adds `changelog_for_version` to WorkspaceInfo and PackageInfo, which uses the same logic in cargo-dist.

I haven't 100% thought out the logic of what should be an Option vs an Err (specifically what cargo-dist and oranda want). Previously cargo-dist would ultimately ignore basically all errors since it was doing the changelog stuff opportunistically.