### PR TITLE
feat: make GithubRepo struct public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,8 @@ pub mod rust;
 #[cfg(test)]
 mod tests;
 
-use crate::repo::{GithubRepo, GithubRepoInput};
+pub use crate::repo::GithubRepo;
+use crate::repo::GithubRepoInput;
 
 /// Information about various kinds of workspaces
 pub struct Workspaces {

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -20,6 +20,7 @@ pub struct GithubRepo {
 }
 
 impl GithubRepo {
+    /// Returns a URL suitable for web access to the repository.
     pub fn web_url(&self) -> String {
         format!("https://github.com/{}/{}", self.owner, self.name)
     }

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -24,6 +24,12 @@ impl GithubRepo {
     pub fn web_url(&self) -> String {
         format!("https://github.com/{}/{}", self.owner, self.name)
     }
+
+    /// Constructs a new Github repository from a "owner/name" string. Notably, this does not check
+    /// whether the repo actually exists.
+    pub fn from_url(repo_url: &str) -> Result<Self> {
+        GithubRepoInput::new(repo_url.to_string())?.parse()
+    }
 }
 
 impl fmt::Display for GithubRepo {

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -108,3 +108,38 @@ impl GithubRepoInput {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_parses_an_https_repo_string() {
+        let input = "https://github.com/axodotdev/oranda";
+        let actual_owner = "axodotdev";
+        let actual_name = "oranda";
+        let parsed = GithubRepo::from_url(input).unwrap();
+        assert_eq!(parsed.owner, actual_owner);
+        assert_eq!(parsed.name, actual_name);
+    }
+
+    #[test]
+    fn it_parses_an_https_repo_string_with_dot_git() {
+        let input = "https://github.com/axodotdev/oranda.git";
+        let actual_owner = "axodotdev";
+        let actual_name = "oranda";
+        let parsed = GithubRepo::from_url(input).unwrap();
+        assert_eq!(parsed.owner, actual_owner);
+        assert_eq!(parsed.name, actual_name);
+    }
+
+    #[test]
+    fn it_parses_an_ssh_repo_string() {
+        let input = "git@github.com:axodotdev/oranda.git";
+        let actual_owner = "axodotdev";
+        let actual_name = "oranda";
+        let parsed = GithubRepo::from_url(input).unwrap();
+        assert_eq!(parsed.owner, actual_owner);
+        assert_eq!(parsed.name, actual_name);
+    }
+}


### PR DESCRIPTION
While the type is exposed by the return type of one function, I missed making the struct itself public.

This also adds an additional helper, and imports the tests from oranda.