### PR TITLE
Reexport guppy type we expose

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,7 +131,7 @@ dependencies = [
  "clap",
  "console",
  "guppy",
- "itertools",
+ "itertools 0.10.5",
  "miette",
  "node-semver",
  "oro-common",
@@ -233,9 +233,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.15.4"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
+checksum = "e7daec1a2a2129eeba1644b220b4647ec537b0b5d4bfd6876fcc5a540056b592"
 dependencies = [
  "camino",
  "cargo-platform",
@@ -617,9 +617,9 @@ checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 
 [[package]]
 name = "guppy"
-version = "0.15.2"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f822a2716041492e071691606474f5a7e4fa7c2acbfd7da7b29884fb448291c7"
+checksum = "0831ad7ff3b6af88fdc493844f02f7ca0ccfe0852cdf19f8c80a0f6223d41fa3"
 dependencies = [
  "camino",
  "cargo_metadata",
@@ -628,7 +628,7 @@ dependencies = [
  "fixedbitset",
  "guppy-workspace-hack",
  "indexmap 1.9.3",
- "itertools",
+ "itertools 0.11.0",
  "nested",
  "once_cell",
  "pathdiff",
@@ -759,6 +759,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]
@@ -1395,13 +1404,14 @@ checksum = "9d0e916b1148c8e263850e1ebcbd046f333e0683c724876bb0da63ea4373dc8a"
 
 [[package]]
 name = "target-spec"
-version = "1.4.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf4306559bd50cb358e7af5692694d6f6fad95cf2c0bea2571dd419f5298e12"
+checksum = "48b81540ee78bd9de9f7dca2378f264cf1f4193da6e2d09b54c0d595131a48f1"
 dependencies = [
  "cfg-expr",
  "guppy-workspace-hack",
  "target-lexicon",
+ "unicode-ident",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ axocli = { version = "0.1.0", optional = true }
 camino = "1.1.4"
 console = "0.15.5"
 miette = "5.6.0"
-guppy = { version = "0.15.2", optional = true }
+guppy = { version = "0.17.1", optional = true }
 tracing = "0.1.37"
 oro-common = { version = "0.3.14", optional = true }
 serde_json = "1.0.94"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,9 @@ use camino::{Utf8Path, Utf8PathBuf};
 use errors::{AxoprojectError, Result};
 use tracing::info;
 
+#[cfg(feature = "cargo-projects")]
+pub use guppy::PackageId;
+
 pub mod changelog;
 pub mod errors;
 #[cfg(feature = "npm-projects")]
@@ -281,7 +284,7 @@ pub struct PackageInfo {
     pub cargo_metadata_table: Option<serde_json::Value>,
     /// A unique id used by Cargo to refer to the package
     #[cfg(feature = "cargo-projects")]
-    pub cargo_package_id: Option<guppy::PackageId>,
+    pub cargo_package_id: Option<PackageId>,
 }
 
 impl PackageInfo {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -539,7 +539,7 @@ pub fn find_file(
             .unwrap_or(true);
 
         if improperly_nested {
-            return Err(AxoassetError::SearchFailed {
+            Err(AxoassetError::SearchFailed {
                 start_dir: start_dir.to_owned(),
                 desired_filename: name.to_owned(),
             })?;


### PR DESCRIPTION
Since we expose a type that comes from the `guppy` crate, switch to reexporting it and use the reexported version. We'll probably want to do this with other types later as well.