### PR TITLE
feat: add generic project type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,6 +99,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "toml",
  "toml_edit",
  "url",
  "walkdir",
@@ -1146,6 +1147,15 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_datetime"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,22 +22,23 @@ name = "axoproject"
 required-features = ["cli"]
 
 [features]
-default = ["cli", "cargo-projects", "npm-projects"]
+default = ["cli", "generic-projects", "cargo-projects", "npm-projects"]
 cli = ["axocli"]
+generic-projects = ["semver"]
 cargo-projects = ["guppy", "semver"]
 npm-projects = ["oro-common", "oro-package-spec", "node-semver"]
 
 [dependencies]
-axoasset = { version = "0.6.0", default-features = false, features = ["json-serde", "toml-edit"] }
+axoasset = { version = "0.6.0", default-features = false, features = ["json-serde", "toml-edit", "toml-serde"] }
 axocli = { version = "0.1.0", optional = true }
-camino = "1.1.4"
+camino = { version = "1.1.4", default-features = true, features = ["serde1"] }
 console = "0.15.5"
 miette = "5.6.0"
 guppy = { version = "0.17.1", optional = true }
 tracing = "0.1.40"
 oro-common = { version = "0.3.34", optional = true }
 serde = "1.0.192"
-semver = { version = "1.0.20", optional = true }
+semver = { version = "1.0.20", optional = true, default-features = true, features = ["serde"] }
 node-semver = { version = "2.1.0", optional = true }
 oro-package-spec = { version = "0.3.34", optional = true }
 thiserror = "1.0.50"

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -1,0 +1,113 @@
+//! Support for generic projects with cargo-dist build instructions
+
+use axoasset::SourceFile;
+use camino::{Utf8Path, Utf8PathBuf};
+use serde::Deserialize;
+
+use crate::{PackageInfo, Result, Version, WorkspaceInfo, WorkspaceSearch};
+
+#[derive(Deserialize)]
+struct Manifest {
+    package: Package,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "kebab-case")]
+struct Package {
+    name: String,
+    repository: Option<String>,
+    homepage: Option<String>,
+    documentation: Option<String>,
+    description: Option<String>,
+    readme: Option<Utf8PathBuf>,
+    #[serde(default = "Vec::new")]
+    authors: Vec<String>,
+    binaries: Vec<String>,
+    license: Option<String>,
+    changelog: Option<Utf8PathBuf>,
+    #[serde(default = "Vec::new")]
+    license_files: Vec<Utf8PathBuf>,
+    #[serde(default = "Vec::new")]
+    cstaticlibs: Vec<String>,
+    #[serde(default = "Vec::new")]
+    cdylibs: Vec<String>,
+    build_command: Vec<String>,
+    version: Option<semver::Version>,
+}
+
+/// Try to find a generic workspace at the given path
+///
+/// See [`crate::get_workspaces`][] for the semantics.
+pub fn get_workspace(start_dir: &Utf8Path, clamp_to_dir: Option<&Utf8Path>) -> WorkspaceSearch {
+    let manifest_path = match crate::find_file("dist.toml", start_dir, clamp_to_dir) {
+        Ok(path) => path,
+        Err(e) => return WorkspaceSearch::Missing(e),
+    };
+
+    match workspace_from(&manifest_path) {
+        Ok(info) => WorkspaceSearch::Found(info),
+        Err(e) => WorkspaceSearch::Broken {
+            manifest_path,
+            cause: e,
+        },
+    }
+}
+
+fn workspace_from(manifest_path: &Utf8Path) -> Result<WorkspaceInfo> {
+    let workspace_dir = manifest_path.parent().unwrap().to_path_buf();
+    let root_auto_includes = crate::find_auto_includes(&workspace_dir)?;
+
+    let manifest: Manifest = load_root_dist_toml(manifest_path)?;
+    let package = manifest.package;
+    let version = package.version.map(Version::Generic);
+
+    let manifest_path = manifest_path.to_path_buf();
+
+    let package_info = PackageInfo {
+        manifest_path: manifest_path.clone(),
+        package_root: manifest_path.clone(),
+        name: package.name,
+        version,
+        description: package.description,
+        authors: package.authors,
+        license: package.license,
+        publish: true,
+        keywords: None,
+        repository_url: package.repository.clone(),
+        homepage_url: package.homepage,
+        documentation_url: package.documentation,
+        readme_file: package.readme,
+        license_files: package.license_files,
+        changelog_file: package.changelog,
+        binaries: package.binaries,
+        cstaticlibs: package.cstaticlibs,
+        cdylibs: package.cdylibs,
+        #[cfg(feature = "cargo-projects")]
+        cargo_metadata_table: None,
+        #[cfg(feature = "cargo-projects")]
+        cargo_package_id: None,
+    };
+
+    Ok(WorkspaceInfo {
+        kind: crate::WorkspaceKind::Generic,
+        target_dir: workspace_dir.join("target"),
+        workspace_dir,
+        package_info: vec![package_info],
+        manifest_path,
+        repository_url: package.repository,
+        root_auto_includes,
+        warnings: vec![],
+        build_command: Some(package.build_command),
+        #[cfg(feature = "cargo-projects")]
+        cargo_metadata_table: None,
+        #[cfg(feature = "cargo-projects")]
+        cargo_profiles: crate::rust::CargoProfiles::new(),
+    })
+}
+
+/// Load the root workspace toml
+fn load_root_dist_toml(manifest_path: &Utf8Path) -> Result<Manifest> {
+    let manifest_src = SourceFile::load_local(manifest_path)?;
+    let manifest = manifest_src.deserialize_toml()?;
+    Ok(manifest)
+}

--- a/src/javascript.rs
+++ b/src/javascript.rs
@@ -148,6 +148,7 @@ fn read_workspace(manifest_path: &Utf8Path) -> Result<WorkspaceInfo> {
         repository_url,
         root_auto_includes,
         warnings: vec![],
+        build_command: None,
         #[cfg(feature = "cargo-projects")]
         cargo_metadata_table: None,
         #[cfg(feature = "cargo-projects")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,8 @@ fn real_main(app: &axocli::CliApp<Cli>) -> Result<(), Report> {
 }
 
 fn print_searches(workspaces: Workspaces) {
+    #[cfg(feature = "generic-projects")]
+    print_search(workspaces.generic, "generic");
     #[cfg(feature = "cargo-projects")]
     print_search(workspaces.rust, "rust");
     #[cfg(feature = "npm-projects")]
@@ -158,6 +160,8 @@ fn print_workspace(project: &WorkspaceInfo) {
 fn print_searches_json(root: Option<&Utf8Path>, workspaces: Workspaces) {
     let output = JsonOutput {
         root: root.map(|p| p.to_owned()),
+        #[cfg(feature = "generic-projects")]
+        generic: JsonWorkspaceSearch::from_real(root, workspaces.generic),
         #[cfg(feature = "cargo-projects")]
         rust: JsonWorkspaceSearch::from_real(root, workspaces.rust),
         #[cfg(feature = "npm-projects")]
@@ -170,6 +174,8 @@ fn print_searches_json(root: Option<&Utf8Path>, workspaces: Workspaces) {
 #[derive(Serialize, Deserialize)]
 struct JsonOutput {
     root: Option<Utf8PathBuf>,
+    #[cfg(feature = "generic-projects")]
+    generic: JsonWorkspaceSearch,
     #[cfg(feature = "cargo-projects")]
     rust: JsonWorkspaceSearch,
     #[cfg(feature = "npm-projects")]
@@ -357,6 +363,10 @@ impl JsonRelPath {
 /// Kind of workspace
 #[derive(Debug, Serialize, Deserialize)]
 pub enum JsonWorkspaceKind {
+    /// generic workspace
+    #[cfg(feature = "generic-projects")]
+    #[serde(rename = "generic")]
+    Generic,
     /// cargo/rust workspace
     #[cfg(feature = "cargo-projects")]
     #[serde(rename = "rust")]
@@ -370,6 +380,8 @@ pub enum JsonWorkspaceKind {
 impl JsonWorkspaceKind {
     fn from_real(real: WorkspaceKind) -> Self {
         match real {
+            #[cfg(feature = "generic-projects")]
+            WorkspaceKind::Generic => Self::Generic,
             #[cfg(feature = "cargo-projects")]
             WorkspaceKind::Rust => Self::Rust,
             #[cfg(feature = "npm-projects")]

--- a/src/rust.rs
+++ b/src/rust.rs
@@ -136,6 +136,7 @@ fn workspace_info(pkg_graph: &PackageGraph) -> Result<WorkspaceInfo> {
         cargo_profiles,
 
         warnings,
+        build_command: None,
     })
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -559,3 +559,19 @@ fn test_changelog_errors() {
         Err(AxoprojectError::ParseChangelog(..))
     ));
 }
+
+#[test]
+fn test_generic_c() {
+    let project = crate::get_workspaces("tests/projects/generic-c/".into(), None)
+        .best()
+        .unwrap();
+    assert_eq!(project.kind, WorkspaceKind::Generic);
+    assert_eq!(project.package_info.len(), 1);
+
+    let package = &project.package_info[0];
+    assert_eq!(package.name, "testprog");
+    assert_eq!(package.binaries.len(), 1);
+
+    let binary = &package.binaries[0];
+    assert_eq!(binary, "main");
+}

--- a/tests/projects/generic-c/Makefile
+++ b/tests/projects/generic-c/Makefile
@@ -1,0 +1,13 @@
+CC := gcc
+RM := rm
+EXEEXT := 
+
+all: main$(EXEEXT)
+
+main$(EXEEXT):
+	$(CC) main.c -o main$(EXEEXT)
+
+clean:
+	$(RM) -f main$(EXEEXT)
+
+.PHONY: all clean

--- a/tests/projects/generic-c/dist.toml
+++ b/tests/projects/generic-c/dist.toml
@@ -1,0 +1,47 @@
+[package]
+name = "testprog"
+description = "A test of a C program for cargo-dist"
+version = "0.0.1"
+license = "WTFPL"
+repository = "https://github.com/mistydemeo/testprog"
+binaries = ["main"]
+build-command = ["make"]
+
+# Config for 'cargo dist'
+[workspace.metadata.dist]
+# The preferred cargo-dist version to use in CI (Cargo.toml SemVer syntax)
+cargo-dist-version = "0.4.2"
+# CI backends to support
+ci = ["github"]
+# The installers to generate for each app
+installers = ["shell", "homebrew"]
+# Target platforms to build apps for (Rust target-triple syntax)
+targets = ["x86_64-unknown-linux-gnu", "aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-musl"]
+# The archive format to use for windows builds (defaults .zip)
+windows-archive = ".tar.gz"
+# The archive format to use for non-windows builds (defaults .tar.xz)
+unix-archive = ".tar.gz"
+# A namespace to use when publishing this package to the npm registry
+npm-scope = "@axodotdev"
+# A GitHub repo to push Homebrew formulas to
+tap = "mistydemeo/homebrew-cargodisttest"
+# Publish jobs to run in CI
+publish-jobs = ["homebrew"]
+# Whether cargo-dist should create a Github Release or use an existing draft
+create-release = false
+# Whether to publish prereleases to package managers
+publish-prereleases = true
+# Publish jobs to run in CI
+pr-run-mode = "plan"
+
+[workspace.metadata.dist.dependencies.homebrew]
+cmake = { targets = ["x86_64-apple-darwin"] }
+libcue = { version = "2.2.1", targets = ["x86_64-apple-darwin"] }
+
+[workspace.metadata.dist.dependencies.apt]
+cmake = '*'
+libcue-dev = { version = "2.2.1-2" }
+
+[workspace.metadata.dist.dependencies.chocolatey]
+lftp = '*'
+cmake = '3.27.6'

--- a/tests/projects/generic-c/main.c
+++ b/tests/projects/generic-c/main.c
@@ -1,0 +1,3 @@
+#include <stdio.h>
+
+int main() { puts("Hello, cargo-dist!"); }


### PR DESCRIPTION
This adds a new project type: generic projects, which represent any sort of project with an axo-specific manifest file. That manifest file, `dist.toml`, contains key information about projects in a very Cargo-like format.

Axoproject parses the `profile` section of `dist.toml` to populate `WorkspaceInfo`; it contains the same core fields as `Cargo.toml` along with a few extra fields that are normally inferred from asking cargo, such as the lists of build artifacts. It also contains the build command to run. The other section, `dist`, we defer to cargo-dist because it contains cargo-dist's config.